### PR TITLE
Scripts & cmake install & ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,5 +10,12 @@ add_executable(tryOpenGL main.cc)
 install(TARGETS tryOpenGL DESTINATION bin)
 
 enable_testing()
-# Does the application run
+# Does the program run
 add_test(NAME Runs COMMAND tryOpenGL)
+
+# Does the program print "Hello world" 
+add_test(NAME PrintsHelloWorld COMMAND tryOpenGL)
+set_tests_properties(
+    PrintsHelloWorld
+    PROPERTIES PASS_REGULAR_EXPRESSION "Hello world"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,3 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 add_executable(tryOpenGL main.cc)
 
 install(TARGETS tryOpenGL DESTINATION bin)
+
+enable_testing()
+# Does the application run
+add_test(NAME Runs COMMAND tryOpenGL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,3 +6,5 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 add_executable(tryOpenGL main.cc)
+
+install(TARGETS tryOpenGL DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,17 +10,17 @@ add_executable(tryOpenGL main.cc)
 install(TARGETS tryOpenGL DESTINATION bin)
 
 enable_testing()
-# Does the program run
+# Test 1: does the program run
 add_test(NAME Runs COMMAND tryOpenGL)
 
-# Does the program print "Hello world" 
+# Test 2: does the program print "Hello world" 
 add_test(NAME PrintsHelloWorld COMMAND tryOpenGL)
 set_tests_properties(
     PrintsHelloWorld
     PROPERTIES PASS_REGULAR_EXPRESSION "Hello world"
 )
 
-# Does the program print "Hello tests" with "--test" 
+# Test 3: does the program print "Hello tests" with "--test" 
 add_test(NAME PrintsHelloTests COMMAND tryOpenGL "--test")
 set_tests_properties(
     PrintsHelloTests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,4 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(tryOpenGL)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
 add_executable(tryOpenGL main.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,3 +19,10 @@ set_tests_properties(
     PrintsHelloWorld
     PROPERTIES PASS_REGULAR_EXPRESSION "Hello world"
 )
+
+# Does the program print "Hello tests" with "--test" 
+add_test(NAME PrintsHelloTests COMMAND tryOpenGL "--test")
+set_tests_properties(
+    PrintsHelloTests
+    PROPERTIES PASS_REGULAR_EXPRESSION "Hello tests"
+)

--- a/scripts/cbr-build.sh
+++ b/scripts/cbr-build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+echo "CBR cmake configure & build"
+
+# From:
+# https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_DIR="${SCRIPT_DIR}/.."
+BUILD_DIR="${REPO_DIR}/build"
+
+pushd ${REPO_DIR}
+mkdir -p ${BUILD_DIR}
+
+pushd ${BUILD_DIR}
+cmake ../
+cmake --build .
+popd
+
+popd

--- a/scripts/cbr-clang-format.sh
+++ b/scripts/cbr-clang-format.sh
@@ -5,7 +5,7 @@ echo "CBR clang-format"
 # From:
 # https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-REPO_DIR="${SCRIPT_DIR}/../"
+REPO_DIR="${SCRIPT_DIR}/.."
 
 pushd ${REPO_DIR}
 # This command may need to be refactored when adding more files

--- a/scripts/cbr-clang-format.sh
+++ b/scripts/cbr-clang-format.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+echo "CBR clang-format"
+
+# From:
+# https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_DIR="${SCRIPT_DIR}/../"
+
+pushd ${REPO_DIR}
+# This command may need to be refactored when adding more files
+clang-format --style=file --verbose -i ./*.cc ./src/*.h
+popd

--- a/scripts/cbr-install.sh
+++ b/scripts/cbr-install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+echo "CBR cmake install"
+
+# From:
+# https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_DIR="${SCRIPT_DIR}/.."
+BUILD_DIR="${REPO_DIR}/build"
+INSTALL_DIR="${BUILD_DIR}/cbr-install"
+
+# Run our build script
+pushd ${SCRIPT_DIR}
+./cbr-build.sh
+popd
+
+pushd ${BUILD_DIR}
+mkdir -p ${INSTALL_DIR}
+cmake --install . --prefix ${INSTALL_DIR}
+popd

--- a/scripts/cbr-test.sh
+++ b/scripts/cbr-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+echo "CBR ctest"
+
+# From:
+# https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_DIR="${SCRIPT_DIR}/.."
+BUILD_DIR="${REPO_DIR}/build"
+
+# Run our build script
+pushd ${SCRIPT_DIR}
+./cbr-build.sh
+popd
+
+pushd ${BUILD_DIR}
+ctest -VV
+popd


### PR DESCRIPTION
### Implements
- Add some scripts to:
  - run `clang-format`
  - run the build
  - run the install steps
  - run tests with `ctest`
- Update our `CMakeLists.txt`  